### PR TITLE
Fix #13

### DIFF
--- a/src/main/java/thaumicperiphery/util/EmberUtil.java
+++ b/src/main/java/thaumicperiphery/util/EmberUtil.java
@@ -3,9 +3,9 @@ package thaumicperiphery.util;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumHand;
-import teamroots.embers.item.IEmberItem;
-import teamroots.embers.item.IHeldEmberCell;
-import teamroots.embers.item.IInventoryEmberCell;
+import teamroots.embers.api.item.IEmberItem;
+import teamroots.embers.api.item.IHeldEmberCell;
+import teamroots.embers.api.item.IInventoryEmberCell;
 
 public class EmberUtil {
 


### PR DESCRIPTION
Embers Rekindled 1.9 moved some of the classes, which causes the game to crash.